### PR TITLE
Serverside rendering should respond with a mobile-first picture

### DIFF
--- a/element-resize-listener.es6
+++ b/element-resize-listener.es6
@@ -49,7 +49,7 @@ export function addElementResizeListener(element, callback) {
   }
   let elementReference = elementsWithResizeListeners.find((item) => item.element === element);
   if (!elementReference) {
-    elementReference = { element, listeners: [], frame: null };
+    elementReference = { element, listeners: [], frame: null, oldWidth: null, oldHeight: null };
     elementsWithResizeListeners.push(elementReference);
   }
   if (elementReference.listeners.indexOf(callback) !== -1) {

--- a/index.es6
+++ b/index.es6
@@ -23,9 +23,6 @@ export default class Picture extends React.Component {
       const isPortrait = currentImageRatio < portraitImageRatioCutoff;
       return isLessWide && isPortrait ? currentSource : previousSource;
     }, sourcesOfDppx[0] || {});
-    // 1190/560 === 2.12
-    // 790/372 === 2.12
-    // 480/390 === 1.23
     this.state = {
       ...smallPortraitSource,
     };

--- a/index.es6
+++ b/index.es6
@@ -14,15 +14,17 @@ export default class Picture extends React.Component {
   constructor({ sources }) {
     super(...arguments);
     this.changeImageByWidth = this.changeImageByWidth.bind(this);
-    const dppx = getClosestDppx(sources);
-    const sourcesOfDppx = sources.filter((source) => source.dppx === dppx);
-    const smallPortraitSource = sourcesOfDppx.reduce((previousSource, currentSource) => {
+    const dppx = 1 || getClosestDppx(sources);
+    const smallPortraitSource = sources.reduce((previousSource, currentSource) => {
+      if (currentSource.dppx !== dppx) {
+        return previousSource;
+      }
       const portraitImageRatioCutoff = 2;
       const isLessWide = currentSource.width < previousSource.width;
       const currentImageRatio = Math.abs(currentSource.width / currentSource.height);
       const isPortrait = currentImageRatio < portraitImageRatioCutoff;
       return isLessWide && isPortrait ? currentSource : previousSource;
-    }, sourcesOfDppx[0] || {});
+    }, sources[0] || {});
     this.state = {
       ...smallPortraitSource,
     };

--- a/index.es6
+++ b/index.es6
@@ -14,7 +14,7 @@ export default class Picture extends React.Component {
   constructor({ sources }) {
     super(...arguments);
     this.changeImageByWidth = this.changeImageByWidth.bind(this);
-    const dppx = 1 || getClosestDppx(sources);
+    const dppx = getClosestDppx(sources);
     const smallPortraitSource = sources.reduce((previousSource, currentSource) => {
       if (currentSource.dppx !== dppx) {
         return previousSource;

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "contents": "window.React = require('react');"
       },
       {
-        "contents": "require('react').render(require('example'),document.getElementById('component-preview'));"
+        "contents": "require('react-dom').render(require('example'),document.getElementById('component-preview'));"
       },
       {
         "contents": "if(document.getElementById('mocha')){mocha.checkLeaks();mocha.run();}"
@@ -102,7 +102,7 @@
   },
   "config": {
     "lint_opts": "--ignore-path .gitignore --ext .es6",
-    "testbundle_opts": "-r react -r .:./index.es6 -r ./example.js:example ./test/*.es6 -o testbundle.js",
+    "testbundle_opts": "-r react -r react-dom -r .:./index.es6 -r ./example.js:example ./test/*.es6 -o testbundle.js",
     "ghpages_files": "*.html *.css *.js assets/"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "browserify": "^11.0.1",
     "chai": "^3.2.0",
     "chai-spies": "^0.6.0",
+    "chai-things": "^0.2.0",
     "cssnext": "^1.8.4",
     "eslint": "^1.3.1",
     "eslint-config-strict": "^5.0.0",


### PR DESCRIPTION
Previous to this the server was assuming that the client wanted the largest image first - or at least the first image it found with a particular `dppx` (in our case this was the largest image.)

1. Server-rendering should respond with a mobile-first picture. We pick the smallest image, as we do not want mobile phones to start downloading the largest file size image; and we also expect this image to be a portrait.
2. On `componentDidMount` we should immediately switch to the correct image even if we're on mobile. The reason I mention this is that previously to this PR the `'resize'` event was not being fired on page load on mobile and was instead being fired when you scrolled.

An assumption has been made that the current server-side fallback `dppx` of `1` is a sensible default. Other assumptions about expected behaviour described above.

Thoughts?