### PR TITLE
Related to TEC-1339 - error fix from this ticket

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,8 +122,8 @@ if (process.env.NODE_ENV !== 'production') {
     sources: React.PropTypes.arrayOf(React.PropTypes.shape({
       url: React.PropTypes.string.isRequired,
       width: React.PropTypes.number.isRequired,
-      height: React.PropTypes.number.isRequired,
-      dppx: React.PropTypes.number.isRequired,
+      height: React.PropTypes.number,
+      dppx: React.PropTypes.number,
       mime: React.PropTypes.string,
     })).isRequired,
   };


### PR DESCRIPTION
In relation to TEC-1339 (https://jira.economist.com/browse/TEC-1339). It was bringing a couple of errors relating to the props being required but not received.

fix: deleted isRequired on height and dppx props to get rid of errors in console