### PR TITLE
WP-1496 prepare for react 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
   directories:
     - node_modules
 node_js:
-  - '4'
+  - '6'
   - stable
 after_success: >-
   travis-after-all && npm run semantic-release && npm run pages -- --repo

--- a/package.json
+++ b/package.json
@@ -103,8 +103,11 @@
     ]
   },
   "dependencies": {
-    "react": "^0.14.8||^15.0.0",
-    "react-dom": "^0.14.8||^15.0.0"
+    "prop-types": "^15.5.0"
+  },
+  "peerDependencies": {
+    "react": "^0.14.8||^15.0.0||^16.0.0",
+    "react-dom": "^0.14.8||^15.0.0||^16.0.0"
   },
   "devDependencies": {
     "@economist/doc-pack": "^1.0.7",
@@ -121,10 +124,11 @@
     "browserify": "^13.0.0",
     "browserify-istanbul": "^2.0.0",
     "chai": "^3.5.0",
-    "chai-enzyme": "^0.4.2",
+    "chai-enzyme": "^1.0.0-beta.0",
     "chai-spies": "^0.7.1",
     "coveralls": "^2.11.9",
-    "enzyme": "^2.3.0",
+    "enzyme": "^3.0.0",
+    "enzyme-adapter-react-16": "^1.0.1",
     "eslint": "^2.8.0",
     "eslint-config-strict": "^8.5.1",
     "eslint-config-strict-react": "^8.0.1",
@@ -153,8 +157,8 @@
     "postcss-import": "^8.1.0",
     "postcss-reporter": "^1.3.3",
     "postcss-url": "^5.1.1",
-    "react-addons-test-utils": "^0.14.8||^15.0.0",
-    "react-dom": "^0.14.8||^15.0.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "semantic-release": "^4.3.5",
     "stylelint": "^6.2.2",
     "stylelint-config-strict": "^5.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { addElementResizeListener, removeElementResizeListener } from './element
 import React from 'react';
 import { findDOMNode as findDomNode } from 'react-dom';
 import { getClosestDppx } from './get-dppx';
+import PropTypes from 'prop-types';
 
 export function getSmallPortraitSource(sources, dppx) {
   return sources.reduce((previousSource, currentSource) => {
@@ -22,21 +23,18 @@ export default class Picture extends React.Component {
     this.changeImageByWidth = this.changeImageByWidth.bind(this);
     this.hasChanged = false;
     const { sources } = props;
-    let isSvgSource = false;
-    sources.forEach((source) => {
-      if (source.mime && source.mime === 'image/svg+xml') {
-        isSvgSource = true;
-        sources[0] = source;
-        return;
-      }
-    });
+    const svgSource = sources
+      .filter((source) => source.mime && source.mime === 'image/svg+xml')
+      .pop();
+    const isSvgSource = Boolean(svgSource);
     let smallPortraitSource = {};
-    if (isSvgSource === false) {
+    if (isSvgSource) {
+      smallPortraitSource = svgSource;
+    } else {
       const dppx = getClosestDppx(sources);
       smallPortraitSource = getSmallPortraitSource(sources, dppx);
-    } else {
-      smallPortraitSource = sources[0];
     }
+
     this.state = {
       ...smallPortraitSource,
       isSvgSource,
@@ -132,20 +130,20 @@ Picture.defaultProps = {
 
 if (process.env.NODE_ENV !== 'production') {
   Picture.propTypes = {
-    itemProp: React.PropTypes.string,
-    className: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.array,
+    itemProp: PropTypes.string,
+    className: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.array,
     ]),
-    classNameObject: React.PropTypes.string,
-    classNameImage: React.PropTypes.string,
-    alt: React.PropTypes.string.isRequired,
-    sources: React.PropTypes.arrayOf(React.PropTypes.shape({
-      url: React.PropTypes.string.isRequired,
-      width: React.PropTypes.number.isRequired,
-      height: React.PropTypes.number,
-      dppx: React.PropTypes.number,
-      mime: React.PropTypes.string,
+    classNameObject: PropTypes.string,
+    classNameImage: PropTypes.string,
+    alt: PropTypes.string.isRequired,
+    sources: PropTypes.arrayOf(PropTypes.shape({
+      url: PropTypes.string.isRequired,
+      width: PropTypes.number.isRequired,
+      height: PropTypes.number,
+      dppx: PropTypes.number,
+      mime: PropTypes.string,
     })).isRequired,
   };
 }

--- a/test/element-resize-listener.js
+++ b/test/element-resize-listener.js
@@ -19,6 +19,11 @@ describe('element-resize-listener', () => {
   let element = null;
   let callback = null;
   let resizeListener = null;
+  const orig = {
+    HTMLElement: globalObject.HTMLElement,
+    addEventListener: globalObject.addEventListener,
+    removeEventListener: globalObject.removeEventListener,
+  };
   beforeEach(() => {
     /* eslint-disable id-match */
     globalObject.HTMLElement = chai.spy();
@@ -29,6 +34,10 @@ describe('element-resize-listener', () => {
     globalObject.removeEventListener = chai.spy();
     element = new globalObject.HTMLElement();
     callback = chai.spy();
+  });
+
+  afterEach(() => {
+    Object.assign(globalObject, orig);
   });
 
   describe('addElementResizeListener', () => {


### PR DESCRIPTION
A few notes from me:

- `enzyme` and `chai-enzyme` are used in the tests, and so have been upgraded.
- Quite a few tests were failing because of careless use of spies - original methods on shared objects were not restored after the tests (e.g. `window.addEventListener`, `dppxUtils.getClosestDppx`, `resizeUtils.addElementResizeListener`, aso). Sadly, `chai-spies` in the latest release has no notion of restoring original methods even though this functionality is present in `chai-spies` master. I had to fallback to manual restoration.
- The component was mutating `props.sources` array, which is [a big no-no](https://reactjs.org/docs/components-and-props.html#props-are-read-only). I had to fix it.
- Enzyme's shallow renderer v3 changed it's behaviour towards lifecycle methods - they are now [called by default](http://airbnb.io/enzyme/docs/guides/migration-from-2-to-3.html#lifecycle-methods) (v2 did not call them by default). Luckily it's easy to control with options passed to to the shallow renderer.